### PR TITLE
Fix for caddy dependency and broken prometheus metrics registration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/oz123/coredns-netbox-plugin
 go 1.15
 
 require (
-	github.com/caddyserver/caddy v1.0.5
+	github.com/coredns/caddy v1.1.1
 	github.com/coredns/coredns v1.7.0
 	github.com/imkira/go-ttlmap v2.0.0+incompatible
 	github.com/miekg/dns v1.1.29

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cloudflare-go v0.10.2/go.mod h1:qhVI5MKwBGhdNU89ZRz2plgYutcJ5PCekLxXn56w6SY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
+github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
 github.com/coredns/coredns v1.7.0 h1:Tm2ZSdhTk+4okgjUp4K6KYzvBI2u34cdD4fKQRC4Eeo=
 github.com/coredns/coredns v1.7.0/go.mod h1:7ohsH7wAKBHd/KqwsTNv5O5lpJXbq25edA/aprpRya4=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/setup.go
+++ b/setup.go
@@ -21,7 +21,7 @@ import (
 	"github.com/coredns/coredns/plugin/metrics"
 	"time"
 
-	"github.com/caddyserver/caddy"
+	"github.com/coredns/caddy"
 )
 
 // init registers this plugin.

--- a/setup.go
+++ b/setup.go
@@ -40,7 +40,15 @@ func setup(c *caddy.Controller) error {
 	// prometheus plugin has been used - if so we will export metrics. We can only register
 	// this metric once, hence the "once.Do".
 	c.OnStartup(func() error {
-		once.Do(func() { metrics.MustRegister(c, requestCount) })
+		once.Do(func() {
+			m := dnsserver.GetConfig(c).Handler("prometheus")
+			if m == nil {
+				return
+			}
+			if x, ok := m.(*metrics.Metrics); ok {
+				x.MustRegister(requestCount)
+			}
+		})
 		return nil
 	})
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/caddyserver/caddy"
+	"github.com/coredns/caddy"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
I ran into #4 and made some necessary changes. The Prometheus code was borrowed from another plugin but I haven't tested it yet. It doesn't prevent the build anymore