### PR TITLE
Fix TTL parsing. Also fix version #32

### DIFF
--- a/netbox.go
+++ b/netbox.go
@@ -77,13 +77,13 @@ func (n *Netbox) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	switch state.QType() {
 	case dns.TypeA:
 		ips, err = n.query(strings.TrimRight(qname, "."), familyIP4)
-		answers = a(qname, uint32(n.TTL), ips)
+		answers = a(qname, uint32(n.TTL.Seconds()), ips)
 	case dns.TypeAAAA:
 		ips, err = n.query(strings.TrimRight(qname, "."), familyIP6)
-		answers = aaaa(qname, uint32(n.TTL), ips)
+		answers = aaaa(qname, uint32(n.TTL.Seconds()), ips)
 	case dns.TypePTR:
 		domains, err = n.queryreverse(qname)
-		answers = ptr(qname, uint32(n.TTL), domains)
+		answers = ptr(qname, uint32(n.TTL.Seconds()), domains)
 	default:
 		// always fallthrough if configured
 		if n.Fall.Through(qname) {

--- a/netbox_test.go
+++ b/netbox_test.go
@@ -17,6 +17,7 @@ package netbox
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
@@ -37,6 +38,7 @@ func TestNetbox(t *testing.T) {
 	nb := newNetbox()
 	nb.Url = "https://example.org/api/ipam/ip-addresses"
 	nb.Token = "s3kr3tt0ken"
+	nb.TTL, _ = time.ParseDuration("60m")
 
 	if nb.Name() != "netbox" {
 		t.Errorf("expected plugin name: %s, got %s", "netbox", nb.Name())
@@ -57,6 +59,11 @@ func TestNetbox(t *testing.T) {
 
 	if IP != "10.0.0.2" {
 		t.Errorf("Expected %v, got %v", "10.0.0.2", IP)
+	}
+
+	TTL := rec.Msg.Answer[0].Header().Ttl
+	if TTL != 3600 {
+		t.Errorf("Expected TTL %v, got %v", 3600, TTL)
 	}
 
 }

--- a/setup.go
+++ b/setup.go
@@ -26,11 +26,11 @@ import (
 	"github.com/coredns/caddy"
 )
 
-var VERSION = "0.1.1-dev"
+var VERSION = "0.5.0"
 
 const (
-	defaultTTL     = 3600            // 3600s
-	defaultTimeout = time.Second * 5 // 5s
+	defaultTTL     = time.Second * 3600 // 3600s
+	defaultTimeout = time.Second * 5    // 5s
 )
 
 // init registers this plugin.


### PR DESCRIPTION
Hi,

I have found a bug with TTL variable which would not allowed user to set custom TTL properly.

Currently if user set `1m` he will get 4165425152 seconds.
